### PR TITLE
Fix dateFormats loading in Grails <3.3

### DIFF
--- a/src/main/groovy/org/grails/plugins/web/Java8GrailsPlugin.groovy
+++ b/src/main/groovy/org/grails/plugins/web/Java8GrailsPlugin.groovy
@@ -45,7 +45,7 @@ This plugin provides support for Java 8 specific functions in a Grails applicati
 
         Field formats
         try {
-            formats = DataBindingGrailsPlugin.getDeclaredField('DEFAULT_DATE_FORMATS')
+            formats = DataBindingGrailsPlugin.getDeclaredField('DATE_FORMATS')
         } catch (NoSuchFieldException e) {
             formats = Settings.getDeclaredField('DATE_FORMATS')
         }


### PR DESCRIPTION
After https://github.com/grails-plugins/grails-java8/commit/dfed06c8b2ef8bbc56176a9e8b121fb4ee4bc74a dateFormats are not correctly loaded from config in Grails 3.2 and below.