### PR TITLE
Use default parser as last resort for ValueConverter

### DIFF
--- a/src/main/groovy/org/grails/plugins/web/Jsr310ConvertersConfiguration.groovy
+++ b/src/main/groovy/org/grails/plugins/web/Jsr310ConvertersConfiguration.groovy
@@ -36,7 +36,7 @@ class Jsr310ConvertersConfiguration {
             @Override
             OffsetDateTime convert(Object value) {
                 convert(value) { String format ->
-                    OffsetDateTime.parse((CharSequence)value, DateTimeFormatter.ofPattern(format))
+                    format ? OffsetDateTime.parse((CharSequence)value, DateTimeFormatter.ofPattern(format)) : OffsetDateTime.parse((CharSequence)value)
                 }
             }
 
@@ -83,7 +83,7 @@ class Jsr310ConvertersConfiguration {
             @Override
             OffsetTime convert(Object value) {
                 convert(value) { String format ->
-                    OffsetTime.parse((CharSequence)value, DateTimeFormatter.ofPattern(format))
+                    format ? OffsetTime.parse((CharSequence)value, DateTimeFormatter.ofPattern(format)) : OffsetTime.parse((CharSequence)value)
                 }
             }
 
@@ -130,7 +130,7 @@ class Jsr310ConvertersConfiguration {
             @Override
             LocalDateTime convert(Object value) {
                 convert(value) { String format ->
-                    LocalDateTime.parse((CharSequence)value, DateTimeFormatter.ofPattern(format))
+                    format ? LocalDateTime.parse((CharSequence)value, DateTimeFormatter.ofPattern(format)) : LocalDateTime.parse((CharSequence)value)
                 }
             }
 
@@ -177,7 +177,7 @@ class Jsr310ConvertersConfiguration {
             @Override
             LocalDate convert(Object value) {
                 convert(value) { String format ->
-                    LocalDate.parse((CharSequence)value, DateTimeFormatter.ofPattern(format))
+                    format ? LocalDate.parse((CharSequence)value, DateTimeFormatter.ofPattern(format)) : LocalDate.parse((CharSequence)value)
                 }
             }
 
@@ -224,7 +224,7 @@ class Jsr310ConvertersConfiguration {
             @Override
             LocalTime convert(Object value) {
                 convert(value) { String format ->
-                    LocalTime.parse((CharSequence)value, DateTimeFormatter.ofPattern(format))
+                    format ? LocalTime.parse((CharSequence)value, DateTimeFormatter.ofPattern(format)) : LocalTime.parse((CharSequence)value)
                 }
             }
 
@@ -271,7 +271,7 @@ class Jsr310ConvertersConfiguration {
             @Override
             ZonedDateTime convert(Object value) {
                 convert(value) { String format ->
-                    ZonedDateTime.parse((CharSequence)value, DateTimeFormatter.ofPattern(format))
+                    format ? ZonedDateTime.parse((CharSequence)value, DateTimeFormatter.ofPattern(format)) : ZonedDateTime.parse((CharSequence)value)
                 }
             }
 
@@ -311,7 +311,7 @@ class Jsr310ConvertersConfiguration {
                     return null
                 }
                 def firstException
-                formatStrings.each { String format ->
+                (formatStrings + [null]).each { String format ->
                     if (dateValue == null) {
                         try {
                             dateValue = (T)callable.call(format)

--- a/src/test/groovy/org/grails/plugins/web/Jsr310ConvertersConfigurationSpec.groovy
+++ b/src/test/groovy/org/grails/plugins/web/Jsr310ConvertersConfigurationSpec.groovy
@@ -17,7 +17,7 @@ import java.time.ZonedDateTime
 class Jsr310ConvertersConfigurationSpec extends Specification {
 
     @Shared
-    List<String> formats = ["yyyy-MM-dd'T'HH:mm:ssZ", "HH:mm:ssZ", "HH:mm:ss", "yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd"]
+    List<String> formats = ["yyyy-MM-dd'T'HH:mm:ssZ", "HH:mm:ssZ", "HH:mm:ss", "yyyy-MM-dd'T'HH:mm:ss", "yyyy/MM/dd"]
 
     @Shared
     Jsr310ConvertersConfiguration config = new Jsr310ConvertersConfiguration(formatStrings: formats)
@@ -54,6 +54,7 @@ class Jsr310ConvertersConfigurationSpec extends Specification {
         converter.targetType == LocalDateTime
         converter.canConvert('')
         converter.convert("1941-01-05T08:00:00") instanceof LocalDateTime
+        converter.convert(LocalDateTime.parse("1941-01-05T08:00:00").toString()) == LocalDateTime.parse("1941-01-05T08:00:00")
     }
 
     void "localDateTimeStructuredBindingEditor"() {
@@ -86,7 +87,8 @@ class Jsr310ConvertersConfigurationSpec extends Specification {
         expect:
         converter.targetType == LocalDate
         converter.canConvert('')
-        converter.convert("1941-01-05") instanceof LocalDate
+        converter.convert("1941/01/05") instanceof LocalDate
+        converter.convert(LocalDate.parse("1941-01-05").toString()) == LocalDate.parse("1941-01-05")
     }
 
     void "localDateStructuredBindingEditor"() {
@@ -117,6 +119,7 @@ class Jsr310ConvertersConfigurationSpec extends Specification {
         converter.targetType == LocalTime
         converter.canConvert('')
         converter.convert("08:00:00") instanceof LocalTime
+        converter.convert(LocalTime.parse("08:00").toString()) == LocalTime.parse("08:00")
     }
 
     void "localTimeStructuredBindingEditor"() {
@@ -147,6 +150,7 @@ class Jsr310ConvertersConfigurationSpec extends Specification {
         converter.targetType == OffsetTime
         converter.canConvert('')
         converter.convert("08:00:00+0000") instanceof OffsetTime
+        converter.convert(OffsetTime.parse("08:00+01:00").toString()) == OffsetTime.parse("08:00+01:00")
     }
 
     void "offsetTimeStructuredBindingEditor"() {
@@ -177,6 +181,7 @@ class Jsr310ConvertersConfigurationSpec extends Specification {
         converter.targetType == OffsetDateTime
         converter.canConvert('')
         converter.convert("1941-01-05T08:00:00+0000") instanceof OffsetDateTime
+        converter.convert(OffsetDateTime.parse("1941-01-05T08:00:00+01:00").toString()) == OffsetDateTime.parse("1941-01-05T08:00:00+01:00")
     }
 
     void "offsetDateTimeStructuredBindingEditor"() {
@@ -210,6 +215,7 @@ class Jsr310ConvertersConfigurationSpec extends Specification {
         converter.targetType == ZonedDateTime
         converter.canConvert('')
         converter.convert("1941-01-05T08:00:00+0000") instanceof ZonedDateTime
+        converter.convert(ZonedDateTime.parse("1941-01-05T08:00:00+01:00").toString()) == ZonedDateTime.parse("1941-01-05T08:00:00+01:00")
     }
 
     void "zonedDateTimeStructuredBindingEditor"() {


### PR DESCRIPTION
Default parser should be used if all configured formats failed.
Currently output of toString() method or JsonConverter is not recognized by ValueConverter unless the format is explicitly added to dateFormats configuration.
I think that produced json should be parsable out of the box. Furthermore default parsers are more robust than string patterns.