### PR TITLE
Add sensible default formats for supported JSR310 formats

### DIFF
--- a/src/main/groovy/org/grails/plugins/web/Java8GrailsPlugin.groovy
+++ b/src/main/groovy/org/grails/plugins/web/Java8GrailsPlugin.groovy
@@ -26,6 +26,30 @@ import java.lang.reflect.Field
 
 class Java8GrailsPlugin extends Plugin {
 
+    public static final String DEFAULT_JSR310_OFFSET_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ"
+    public static final String DEFAULT_JSR310_OFFSET_TIME_FORMAT = "HH:mm:ssZ"
+    public static final String DEFAULT_JSR310_LOCAL_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss"
+    public static final String DEFAULT_JSR310_LOCAL_DATE_FORMAT = "yyyy-MM-dd"
+    public static final String DEFAULT_JSR310_LOCAL_TIME_FORMAT = "HH:mm:ss"
+    public static final String DEFAULT_JSR310_ZONED_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ"
+
+    /**
+     * Default JSR310 Date formats. Used when no custom formats are supplied.
+     *
+     * Note: the JSR310 formats extend the defaults provided in {@link DataBindingGrailsPlugin#DEFAULT_DATE_FORMATS}
+     *
+     * Note 2: currently {@link #DEFAULT_JSR310_OFFSET_DATE_TIME_FORMAT} == {@link #DEFAULT_JSR310_ZONED_DATE_TIME_FORMAT},
+     *         but both are included for completeness/documentation, or in case either format changes.
+     */
+    public static final Set<String> DEFAULT_JSR310_FORMATS = [
+            DEFAULT_JSR310_OFFSET_DATE_TIME_FORMAT,
+            DEFAULT_JSR310_OFFSET_TIME_FORMAT,
+            DEFAULT_JSR310_LOCAL_DATE_TIME_FORMAT,
+            DEFAULT_JSR310_LOCAL_DATE_FORMAT,
+            DEFAULT_JSR310_LOCAL_TIME_FORMAT,
+            DEFAULT_JSR310_ZONED_DATE_TIME_FORMAT
+    ] + DataBindingGrailsPlugin.DEFAULT_DATE_FORMATS
+
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "3.2.1 > *"
 
@@ -45,15 +69,7 @@ This plugin provides support for Java 8 specific functions in a Grails applicati
 
     Closure doWithSpring() {{->
 
-        Field formats
-        try {
-            formats = DataBindingGrailsPlugin.getDeclaredField('DATE_FORMATS')
-        } catch (NoSuchFieldException e) {
-            formats = Settings.getDeclaredField('DATE_FORMATS')
-        }
-        String dateFormatProperty = formats.get(null)
-
-        List dateFormats = config.getProperty(dateFormatProperty, List, DataBindingGrailsPlugin.DEFAULT_DATE_FORMATS)
+        Set<String> dateFormats = getDateFormats()
 
         if (ClassUtils.isPresent('org.grails.plugins.web.GrailsTagDateHelper')) {
             grailsTagDateHelper(Jsr310TagDateHelper)
@@ -69,6 +85,27 @@ This plugin provides support for Java 8 specific functions in a Grails applicati
         }
 
     }}
+
+    /**
+     * Get the configured date formats.
+     *
+     * Tries to:
+     *  1. Load any configured date formats
+     *  2. Falls back to the {@link #DEFAULT_JSR310_FORMATS} for sensible defaults
+     *
+     * @return a set of formats to use when binding dates via {@link Jsr310ConvertersConfiguration}
+     */
+    Set<String> getDateFormats() {
+        Field formats
+        try {
+            formats = DataBindingGrailsPlugin.getDeclaredField('DATE_FORMATS')
+        } catch (NoSuchFieldException e) {
+            formats = Settings.getDeclaredField('DATE_FORMATS')
+        }
+        String dateFormatProperty = formats.get(null)
+
+        return config.getProperty(dateFormatProperty, Set, DEFAULT_JSR310_FORMATS)
+    }
 
     @Override
     void doWithApplicationContext() {

--- a/src/main/groovy/org/grails/plugins/web/Jsr310ConvertersConfiguration.groovy
+++ b/src/main/groovy/org/grails/plugins/web/Jsr310ConvertersConfiguration.groovy
@@ -13,7 +13,7 @@ import java.time.format.DateTimeFormatter
 @Configuration
 class Jsr310ConvertersConfiguration {
 
-    List<String> formatStrings = []
+    Set<String> formatStrings = []
 
     @Bean
     FormattedValueConverter offsetDateTimeConverter() {

--- a/src/test/groovy/org/grails/plugins/web/Jsr310ConvertersConfigurationSpec.groovy
+++ b/src/test/groovy/org/grails/plugins/web/Jsr310ConvertersConfigurationSpec.groovy
@@ -1,35 +1,20 @@
 package org.grails.plugins.web
 
-import org.grails.plugins.databinding.DataBindingGrailsPlugin
 import spock.lang.Shared
 import spock.lang.Specification
 
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
-import java.time.Month
-import java.time.OffsetDateTime
-import java.time.OffsetTime
-import java.time.Period
-import java.time.ZoneId
-import java.time.ZoneOffset
-import java.time.ZonedDateTime
+import java.time.*
 
 class Jsr310ConvertersConfigurationSpec extends Specification {
 
     @Shared
-    List<String> formats = ["yyyy-MM-dd'T'HH:mm:ssZ", "HH:mm:ssZ", "HH:mm:ss", "yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd"]
-
-    @Shared
-    Jsr310ConvertersConfiguration config = new Jsr310ConvertersConfiguration(formatStrings: formats)
+    Jsr310ConvertersConfiguration config = new Jsr310ConvertersConfiguration(formatStrings: Java8GrailsPlugin.DEFAULT_JSR310_FORMATS)
 
     @Shared
     LocalDate localDate = LocalDate.of(1941, 1, 5)
 
     @Shared
     LocalTime localTime = LocalTime.of(8, 0, 0, 0)
-
-
 
 
     @Shared
@@ -45,7 +30,7 @@ class Jsr310ConvertersConfigurationSpec extends Specification {
 
         expect:
         converter.targetType == LocalDateTime
-        converter.convert("1941-01-05T08:00:00", "yyyy-MM-dd'T'HH:mm:ss") instanceof LocalDateTime
+        converter.convert("1941-01-05T08:00:00", Java8GrailsPlugin.DEFAULT_JSR310_LOCAL_DATE_TIME_FORMAT) instanceof LocalDateTime
     }
 
     void "localDateTimeValueConverter"() {
@@ -78,7 +63,7 @@ class Jsr310ConvertersConfigurationSpec extends Specification {
 
         expect:
         converter.targetType == LocalDate
-        converter.convert("1941-01-05", "yyyy-MM-dd") instanceof LocalDate
+        converter.convert("1941-01-05", Java8GrailsPlugin.DEFAULT_JSR310_LOCAL_DATE_FORMAT) instanceof LocalDate
     }
 
     void "localDateValueConverter"() {
@@ -108,7 +93,7 @@ class Jsr310ConvertersConfigurationSpec extends Specification {
 
         expect:
         converter.targetType == LocalTime
-        converter.convert("08:00:00", "HH:mm:ss") instanceof LocalTime
+        converter.convert("08:00:00", Java8GrailsPlugin.DEFAULT_JSR310_LOCAL_TIME_FORMAT) instanceof LocalTime
     }
 
     void "localTimeValueConverter"() {
@@ -138,7 +123,7 @@ class Jsr310ConvertersConfigurationSpec extends Specification {
 
         expect:
         converter.targetType == OffsetTime
-        converter.convert("08:00:00+0000", "HH:mm:ssZ") instanceof OffsetTime
+        converter.convert("08:00:00+0000", Java8GrailsPlugin.DEFAULT_JSR310_OFFSET_TIME_FORMAT) instanceof OffsetTime
     }
 
     void "offsetTimeValueConverter"() {
@@ -168,7 +153,7 @@ class Jsr310ConvertersConfigurationSpec extends Specification {
 
         expect:
         converter.targetType == OffsetDateTime
-        converter.convert("1941-01-05T08:00:00+0000", "yyyy-MM-dd'T'HH:mm:ssZ") instanceof OffsetDateTime
+        converter.convert("1941-01-05T08:00:00+0000", Java8GrailsPlugin.DEFAULT_JSR310_OFFSET_DATE_TIME_FORMAT) instanceof OffsetDateTime
     }
 
     void "offsetDateTimeValueConverter"() {
@@ -201,7 +186,7 @@ class Jsr310ConvertersConfigurationSpec extends Specification {
 
         expect:
         converter.targetType == ZonedDateTime
-        converter.convert("1941-01-05T08:00:00+0000", "yyyy-MM-dd'T'HH:mm:ssZ") instanceof ZonedDateTime
+        converter.convert("1941-01-05T08:00:00+0000", Java8GrailsPlugin.DEFAULT_JSR310_ZONED_DATE_TIME_FORMAT) instanceof ZonedDateTime
     }
 
     void "zonedDateTimeValueConverter"() {


### PR DESCRIPTION
* Allows overriding of formats via configuration
* Provides sensible default formats for supported java.time.* classes
* Resolves #10